### PR TITLE
BUGFIX: Add missing return type hint to Test

### DIFF
--- a/Tests/Unit/Domain/Job/ExecuteMigrationJobTest.php
+++ b/Tests/Unit/Domain/Job/ExecuteMigrationJobTest.php
@@ -24,7 +24,7 @@ class ExecuteMigrationJobTest extends UnitTestCase
      */
     private $migrationService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
The missing type hint causes the Unit Tests to fail without errors on Flow 6.3